### PR TITLE
Add a check for boost and add its include directory to the build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required (VERSION 2.6)
 project (wASTRAL)
 
+FIND_PACKAGE(Boost)
+IF (Boost_FOUND)
+    INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIR})
+    ADD_DEFINITIONS( "-DHAS_BOOST" )
+ENDIF()
+
+
 link_directories(/usr/local/lib )
 file(GLOB SOURCES *.cpp)
 add_definitions(-std=c++11 -g -O3 -Wall -fopenmp)


### PR DESCRIPTION
Added a boost check to make sure multi_array is found for boost installs not in the system root. Otherwise a wASTRAL/src/Quartet.hpp:4:33: fatal error: boost/multi_array.hpp: No such file or directory will come up.
